### PR TITLE
mako & lge_touch: Support replacement touchscreens which don't have f…

### DIFF
--- a/drivers/input/touchscreen/lge_touch_core.c
+++ b/drivers/input/touchscreen/lge_touch_core.c
@@ -1826,6 +1826,10 @@ static int touch_probe(struct i2c_client *client,
 			: ts->pdata->caps->y_max,
 			0, 0);
 
+	/* Perform device-specific initialisation before reading
+	   capabilities */
+	touch_ic_init(ts);
+
 	/* Copy for efficient handling */
 	is_pressure = ts->pdata->caps->is_pressure_supported;
 	is_width_major = ts->pdata->caps->is_width_major_supported;
@@ -1875,9 +1879,6 @@ static int touch_probe(struct i2c_client *client,
 			ktime_set(0, ts->pdata->role->report_period),
 					HRTIMER_MODE_REL);
 	}
-
-	/* Specific device initialization */
-	touch_ic_init(ts);
 
 	/* Firmware Upgrade Check - use thread for booting time reduction */
 	if (touch_device_func->fw_upgrade) {

--- a/drivers/input/touchscreen/touch_synaptics.c
+++ b/drivers/input/touchscreen/touch_synaptics.c
@@ -466,6 +466,7 @@ static int read_page_description_table(struct i2c_client* client)
 
 int get_ic_info(struct synaptics_ts_data* ts, struct touch_fw_info* fw_info)
 {
+	struct touch_platform_data *pdata = ts->pdata;
 #if defined(ARRAYED_TOUCH_FW_BIN)
 	int cnt;
 #endif
@@ -511,20 +512,28 @@ int get_ic_info(struct synaptics_ts_data* ts, struct touch_fw_info* fw_info)
 		strncpy(fw_info->fw_image_product_id,
 				&SynaFirmware[cnt][FW_OFFSET_PRODUCT_ID], 10);
 		if (!(strncmp(fw_info->product_id,
-				fw_info->fw_image_product_id, 10)))
+				fw_info->fw_image_product_id, 10))) {
+			fw_info->fw_start = (unsigned char *)&SynaFirmware[cnt][0];
+			fw_info->fw_size = sizeof(SynaFirmware[0]);
 			break;
+		}
 	}
-	fw_info->fw_start = (unsigned char *)&SynaFirmware[cnt][0];
-	fw_info->fw_size = sizeof(SynaFirmware[0]);
 #else
 	fw_info->fw_start = (unsigned char *)&SynaFirmware[0];
 	fw_info->fw_size = sizeof(SynaFirmware);
 #endif
 
-	strncpy(fw_info->fw_image_product_id,
-				&fw_info->fw_start[FW_OFFSET_PRODUCT_ID], 10);
-	strncpy(fw_info->fw_image_version,
-					&fw_info->fw_start[FW_OFFSET_IMAGE_VERSION],4);
+	if (fw_info->fw_start == 0) {
+		TOUCH_INFO_MSG("No firmware found for touch controller, assuming no pressure");
+		pdata->caps->is_pressure_supported = 0;
+		strncpy(fw_info->fw_image_product_id, "UNKNOWN", 10);
+		strncpy(fw_info->fw_image_version, "UNK", 4);
+	} else {
+		strncpy(fw_info->fw_image_product_id,
+			&fw_info->fw_start[FW_OFFSET_PRODUCT_ID], 10);
+		strncpy(fw_info->fw_image_version,
+			&fw_info->fw_start[FW_OFFSET_IMAGE_VERSION], 4);
+	}
 
 	if (unlikely(touch_i2c_read(ts->client, FLASH_CONTROL_REG,
 				sizeof(flash_control), &flash_control) < 0)) {
@@ -1079,6 +1088,11 @@ int synaptics_ts_ic_ctrl(struct i2c_client *client, u8 code, u16 value)
 
 int synaptics_ts_fw_upgrade_check(struct lge_touch_data *ts)
 {
+	if (ts->fw_info.fw_start == 0) {
+		TOUCH_INFO_MSG("DO NOT UPDATE device has no firmware\n");
+		return -1;
+	}
+
 	if (ts->fw_info.fw_force_rework || ts->fw_upgrade.fw_force_upgrade) {
 		TOUCH_INFO_MSG("FW-upgrade Force Rework.\n");
 	} else {


### PR DESCRIPTION
…irmware

Fixes bug where if touchscreen firmware wasn't found in compiled in
firmwares, the fw_start pointer would reference invalid memory.

Also allows for third party replacement touchscreens available for mako
which don't send pressure data. These currently only work on Android
4.x. With this patch they also work in Android 5.

Tested with an original mako touchscreen (product id PLG137) and a third
party touchscreen (product id TM2369).

Change-Id: I82864ba01cf6400da5d8410f0f83cf18c28fefe9
Signed-off-by: Angus Gratton gus@projectgus.com
