### PR TITLE
persistent_ram: Fix buffer size clamping during writes

### DIFF
--- a/drivers/staging/android/persistent_ram.c
+++ b/drivers/staging/android/persistent_ram.c
@@ -79,23 +79,6 @@ static inline void buffer_size_add(struct persistent_ram_zone *prz, size_t a)
 	} while (atomic_cmpxchg(&prz->buffer->size, old, new) != old);
 }
 
-/* increase the size counter, retuning an error if it hits the max size */
-static inline ssize_t buffer_size_add_clamp(struct persistent_ram_zone *prz,
-	size_t a)
-{
-	size_t old;
-	size_t new;
-
-	do {
-		old = atomic_read(&prz->buffer->size);
-		new = old + a;
-		if (new > prz->buffer_size)
-			return -ENOMEM;
-	} while (atomic_cmpxchg(&prz->buffer->size, old, new) != old);
-
-	return 0;
-}
-
 static void notrace persistent_ram_encode_rs8(struct persistent_ram_zone *prz,
 	uint8_t *data, size_t len, uint8_t *ecc)
 {
@@ -304,7 +287,7 @@ int notrace persistent_ram_write(struct persistent_ram_zone *prz,
 		c = prz->buffer_size;
 	}
 
-	buffer_size_add_clamp(prz, c);
+	buffer_size_add(prz, c);
 
 	start = buffer_start_add(prz, c);
 


### PR DESCRIPTION
commit 484dd30e016eb425b0de871357fff2c9bb93be45 upstream.

This is a longstanding bug, almost unnoticeable when calling
persistent_ram_write() for small buffers.

But when called for large data buffers, the write routine behaves
incorrectly, as the size may never update: instead of clamping
the size to the maximum buffer size, buffer_size_add_clamp() returns
an error (which is never checked by the write routine, btw).

To fix this, we now use buffer_size_add() that actually clamps the
size to the max value.

Also remove buffer_size_add_clamp(), it is no longer needed.

Change-Id: Iedde6ab812153ad47aabed3dfe5060356cdeeb55
Signed-off-by: Anton Vorontsov anton.vorontsov@linaro.org
Acked-by: Colin Cross ccross@android.com
Signed-off-by: Greg Kroah-Hartman gregkh@linuxfoundation.org
